### PR TITLE
Improve mobile fullscreen support

### DIFF
--- a/script.js
+++ b/script.js
@@ -66,8 +66,17 @@
       }
 
       // --- p5.js Setup Function ---
+      function getCanvasDimensions() {
+        if (windowWidth <= 480) {
+          return { w: windowWidth, h: windowHeight };
+        }
+        return { w: windowWidth * 0.8, h: windowHeight * 0.7 };
+      }
+
+      // --- p5.js Setup Function ---
       function setup() {
-        let canvas = createCanvas(windowWidth * 0.8, windowHeight * 0.7);
+        const { w, h } = getCanvasDimensions();
+        let canvas = createCanvas(w, h);
         canvas.parent(document.getElementById("game-root"));
         groundLevel = height * 0.85 + groundAdjustment;
         textAlign(CENTER, CENTER);
@@ -398,7 +407,8 @@
 
       // --- p5.js Window Resize Function ---
       function windowResized() {
-        resizeCanvas(windowWidth * 0.8, windowHeight * 0.7);
+        const { w, h } = getCanvasDimensions();
+        resizeCanvas(w, h);
         groundLevel = height * 0.85 + groundAdjustment;
         if (player) {
           player.baseY = groundLevel - player.h;

--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,18 @@ canvas {
   margin-top: 10px;
 }
 
+@media (max-width: 480px) {
+  body {
+    justify-content: flex-start;
+  }
+  canvas {
+    width: 100vw;
+    height: 100vh;
+    border: none;
+    margin-top: 0;
+  }
+}
+
 #game-info {
   margin-top: 1rem;
   font-family: "Glass Antiqua", cursive;


### PR DESCRIPTION
## Summary
- allow canvas to take full width/height on small screens
- tweak CSS so there is no gray border around the game on mobile

## Testing
- `npm test` *(fails: package.json missing)*