### PR TITLE
Improve mobile fullscreen support

### DIFF
--- a/script.js
+++ b/script.js
@@ -66,8 +66,21 @@
       }
 
       // --- p5.js Setup Function ---
+      function isMobileSize() {
+        return windowWidth <= 480 || windowHeight <= 480;
+      }
+
+      function getCanvasDimensions() {
+        if (isMobileSize()) {
+          return { w: windowWidth, h: windowHeight };
+        }
+        return { w: windowWidth * 0.8, h: windowHeight * 0.7 };
+      }
+
+      // --- p5.js Setup Function ---
       function setup() {
-        let canvas = createCanvas(windowWidth * 0.8, windowHeight * 0.7);
+        const { w, h } = getCanvasDimensions();
+        let canvas = createCanvas(w, h);
         canvas.parent(document.getElementById("game-root"));
         groundLevel = height * 0.85 + groundAdjustment;
         textAlign(CENTER, CENTER);
@@ -398,7 +411,8 @@
 
       // --- p5.js Window Resize Function ---
       function windowResized() {
-        resizeCanvas(windowWidth * 0.8, windowHeight * 0.7);
+        const { w, h } = getCanvasDimensions();
+        resizeCanvas(w, h);
         groundLevel = height * 0.85 + groundAdjustment;
         if (player) {
           player.baseY = groundLevel - player.h;
@@ -421,7 +435,7 @@
         if (!orientationOverlay) {
           orientationOverlay = document.getElementById("orientation-overlay");
         }
-        const isSmall = window.innerWidth <= 480;
+        const isSmall = window.innerWidth <= 480 || window.innerHeight <= 480;
         const isPortrait = window.innerHeight > window.innerWidth;
         if (orientationOverlay) {
           if (isSmall && isPortrait) {

--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,18 @@ canvas {
   margin-top: 10px;
 }
 
+@media (max-width: 480px), (max-height: 480px) {
+  body {
+    justify-content: flex-start;
+  }
+  canvas {
+    width: 100vw;
+    height: 100vh;
+    border: none;
+    margin-top: 0;
+  }
+}
+
 #game-info {
   margin-top: 1rem;
   font-family: "Glass Antiqua", cursive;


### PR DESCRIPTION
## Summary
- allow canvas to take full width/height on small screens
- tweak CSS so there is no gray border around the game on mobile
- make fullscreen adjustments work in landscape orientation too

## Testing
- `npm test` *(fails: package.json missing)*